### PR TITLE
Move base dir for netlify to docs

### DIFF
--- a/docs/book/netlify.toml
+++ b/docs/book/netlify.toml
@@ -1,3 +1,0 @@
-[build]
-command = "rustup default stable && curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash && cargo binstall --git https://github.com/Myriad-Dreamin/shiroa shiroa@0.3.1 && shiroa build --mode static-html --workspace .."
-publish = "dist"

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+command = "rustup default stable && curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash && cargo binstall --git https://github.com/Myriad-Dreamin/shiroa shiroa@0.3.1 && shiroa build book --mode static-html --workspace ."
+publish = "book/dist"


### PR DESCRIPTION
Otherwise, Netlify will skip PR previews when there are no changes in `book`. But it should build them when there are changes in other parts of `docs` like `content`.